### PR TITLE
Fix require cycles warning by moving the registerInterceptor function

### DIFF
--- a/src/api/apiConfig.ts
+++ b/src/api/apiConfig.ts
@@ -1,8 +1,5 @@
 import axios from 'axios';
 
-import {authService} from '../domain/Auth/authService';
-import {AuthCredentials} from '../domain/Auth/authTypes';
-
 export const BASE_URL = 'http://localhost:3333/';
 export const api = axios.create({
   baseURL: BASE_URL,
@@ -11,44 +8,3 @@ export const api = axios.create({
   //     'Bearer MQ.1QdZ5zs-bM6ctmN9wHDQzr74zuD6E8qrWlCNoBaKsgpX3S6NjTJawj2bEzFc',
   // },
 });
-
-type InterceptorProps = {
-  authCredentials: AuthCredentials | null;
-  removeCredentials: () => Promise<void>;
-  saveCredentials: (ac: AuthCredentials) => Promise<void>;
-};
-export function registerInterceptor({
-  authCredentials,
-  removeCredentials,
-  saveCredentials,
-}: InterceptorProps) {
-  const interceptor = api.interceptors.response.use(
-    response => response,
-    async responseError => {
-      const failedRequest = responseError.config;
-      const hasNotRefreshToken = !authCredentials?.refreshToken;
-      const isRefreshTokenRequest =
-        authService.isRefreshTokenRequest(failedRequest);
-
-      if (responseError.response.status === 401) {
-        if (hasNotRefreshToken || isRefreshTokenRequest || failedRequest.sent) {
-          removeCredentials();
-          return Promise.reject(responseError);
-        }
-
-        failedRequest.sent = true;
-
-        const newAuthCredentials = await authService.authenticateByRefreshToken(
-          authCredentials.refreshToken,
-        );
-        saveCredentials(newAuthCredentials);
-
-        failedRequest.headers.Authorization = `Bearer ${newAuthCredentials.token}`;
-        return api(failedRequest);
-      }
-      return Promise.reject(responseError);
-    },
-  );
-  //remove listen quando o componente é desmontado
-  return () => api.interceptors.response.eject(interceptor);
-}


### PR DESCRIPTION
Esse warning the "Require cycle" ocorre quando a gente importa o modulo A dentro do modulo B, mas o modulo B também utiliza o modulo A. Nesse caso o `apiConfig` estava usando o `authService` que por sua vez estava usando o `apiConfig`

![image](https://github.com/user-attachments/assets/7b24aa73-a66b-4d52-8953-a65e68f654d7)

A forma que a gente tem para corrigir esse problema é reestruturar os arquivos para remover esse dependência circular. Então eu movi a função `registerInterceptor` para onde ela está sendo usada, removendo assim a dependência do `apiConfig`  do módulo `authService`. 

Obs: Eu to investigando porque no meu projeto https://github.com/LucasGarcez/NubbleApp mesmo havendo essa dependência o warning não tá sendo disparado. Teoricamente deveria porque há uma dependência cíclica, ou talvez eu esteja deixando passar algo. Mas enfim, por hora essa refatoração resolve seu problema. 
